### PR TITLE
Remove clamp to prevent the gradient to be nan

### DIFF
--- a/libs/residual2vec/README.md
+++ b/libs/residual2vec/README.md
@@ -85,6 +85,7 @@ Several samplers are implemented in this package:
 - `ErdosRenyiNodeSampler`: Sampler based on the Erdos Renyi random graph (i.e., sample context node with the same probability)
 - `ConfigModelNodeSampler`: Sampler based on the configuration model (i.e., sample context node with probability proportional to its degree)
 - `SBMNodeSampler`: Sampler based on the stochastic block model (i.e., sample context node using the stochastic block model)
+- `ConditionalContextSampler`: Sampling a random context node conditioned on the group to which a given context node blongs. The group membership needs to be given when creating this instance (experimental).
 
 The `SBMNodeSampler` is useful to negate the bias due to a group structure in networks (i.e., structure correlated with a discrete label of nodes):
 

--- a/libs/residual2vec/residual2vec/node_samplers.py
+++ b/libs/residual2vec/residual2vec/node_samplers.py
@@ -122,7 +122,7 @@ class ConditionalContextSampler(NodeSampler):
     """Node Sampler conditioned on group membership."""
 
     def __init__(
-        self, group_membership=None,
+        self, group_membership,
     ):
         """Node Sampler conditioned on group membership.
 

--- a/libs/residual2vec/residual2vec/node_samplers.py
+++ b/libs/residual2vec/residual2vec/node_samplers.py
@@ -15,13 +15,17 @@ class NodeSampler:
         """
         raise NotImplementedError
 
-    def sampling(self, center_node, n_samples):
+    def sampling(self, center_nodes, context_nodes, n_samples, padding_id):
         """Sample context nodes from the graph for center nodes.
 
-        :param center_node: ID of center node
-        :type center_node: int
+        :param center_nodes: ID of center node
+        :type center_nodes: int
+        :param context_nodes: ID of context node
+        :type context_nodes: int
         :param n_samples: number of samples per center node
         :type n_samples: int
+        :param padding_idx: ID of padding
+        :type padding_id: int
         :raises NotImplementedError: [description]
         """
         raise NotImplementedError
@@ -33,7 +37,7 @@ class SBMNodeSampler(NodeSampler):
     def __init__(
         self, window_length=10, group_membership=None, dcsbm=True,
     ):
-        """Node Sampler based on the stochatic block model.
+        """Node Sampler based on the stochastic block model.
 
         :param window_length: length of the context window, defaults to 10
         :type window_length: int, optional
@@ -95,7 +99,7 @@ class SBMNodeSampler(NodeSampler):
             self.block2node.indptr, self.block2node.data
         )
 
-    def sampling(self, center_nodes, n_samples):
+    def sampling(self, center_nodes, context_nodes, n_samples, padding_id):
         _center_nodes = np.repeat(center_nodes, n_samples)
         block_ids = utils.csr_sampling(
             self.group_membership[_center_nodes], self.block2block
@@ -112,3 +116,52 @@ class ConfigModelNodeSampler(SBMNodeSampler):
 class ErdosRenyiNodeSampler(SBMNodeSampler):
     def __init__(self):
         super(ErdosRenyiNodeSampler, self).__init__(window_length=1, dcsbm=False)
+
+
+class ConditionalContextSampler(NodeSampler):
+    """Node Sampler conditioned on group membership."""
+
+    def __init__(
+        self, group_membership=None,
+    ):
+        """Node Sampler conditioned on group membership.
+
+        :param window_length: length of the context window, defaults to 10
+        :type window_length: int, optional
+        :param group_membership: group membership of nodes, defaults to None
+        :type group_membership: np.ndarray, optional
+        :param dcsbm: Set dcsbm=True to take into account the degree of nodes, defaults to True
+        :type dcsbm: bool, optional
+        """
+
+        # Reindex the group membership
+        labels, group_membership = np.unique(group_membership, return_inverse=True)
+        self.group_membership = group_membership
+        n = len(group_membership)
+        k = len(labels)
+        self.block2node = sparse.csr_matrix(
+            (
+                np.ones_like(self.group_membership),
+                (self.group_membership, np.arange(n)),
+            ),
+            shape=(k, n),
+        )
+
+    def fit(self, A):
+        # Assuming that context is sampled from a random walk
+        indeg = np.array(A.sum(axis=0)).reshape(-1)
+        self.block2node = self.block2node @ sparse.diags(indeg)
+        self.block2node.data = utils._csr_row_cumsum(
+            self.block2node.indptr, self.block2node.data
+        )
+        return
+
+    def sampling(self, center_nodes, context_nodes, n_samples, padding_id):
+        _context_nodes = context_nodes.reshape(-1)
+        mask = _context_nodes == padding_id
+        _context_nodes[mask] = 0
+        context = utils.csr_sampling(
+            self.group_membership[_context_nodes], self.block2node
+        )
+        context[mask] = padding_id
+        return context.astype(np.int64).reshape(context_nodes.shape)

--- a/libs/residual2vec/residual2vec/residual2vec_sgd.py
+++ b/libs/residual2vec/residual2vec/residual2vec_sgd.py
@@ -300,7 +300,10 @@ class TripletDataset(Dataset):
             padding_id=self.padding_id,
         )
         self.random_contexts = self.noise_sampler.sampling(
-            self.centers, self.contexts.shape[1]
+            center_nodes=self.centers,
+            context_nodes=self.contexts,
+            n_samples=self.contexts.shape[1],
+            padding_id=self.padding_id,
         )
         self.n_sampled = len(self.centers)
         self.scanned_node_id = next_scanned_node_id % self.n_nodes

--- a/libs/residual2vec/setup.py
+++ b/libs/residual2vec/setup.py
@@ -5,7 +5,7 @@ from os import path
 
 from setuptools import find_packages, setup
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 
 def load_requires_from_file(fname):


### PR DESCRIPTION
# Update
- Stop using `.clamp` in the computation of the sigmoid function. `clamp` has been used for the numerical stability of the sigmoid function. But later, I found that, when using `clamp` function, sometimes the gradient becomes nan, and this breaks the embedding. PyTorch community is aware of this problem and recommends using 'logsigmoid' function, instead. So, in this new version, the logsimoid function is used. 
- Add an experimental sampler `ConditionalContextSampler`. This sampler takes group memberships of nodes, and samples a random context from a group that a given context belongs to. May be useful to control the effect of group structure. 