### PR TITLE
Adding single context window

### DIFF
--- a/libs/residual2vec/setup.py
+++ b/libs/residual2vec/setup.py
@@ -5,7 +5,7 @@ from os import path
 
 from setuptools import find_packages, setup
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 
 def load_requires_from_file(fname):


### PR DESCRIPTION
# Update
- Implemented a single window that extends leftward or rightward of a center node. This feature may be useful to embed directed networks. Available only for the pytorch version of the residual2vec

# How to specify the context window types

The residual2vec_sgd takes a new argument `context_window_type` that specifies the type of context window. The default is `double`:

```python
context_window_type = 'left' # {'left', 'right', 'double'} 
rv.residual2vec_sgd(context_window_type=context_window_type)
```

`context_window_type="double"` specifies the context window that extends both left and right of a focal node. context_window_type="left" or ="right" specifies that extends left or right, respectively.
 